### PR TITLE
[Fix] Close task

### DIFF
--- a/lib/src/file/download_file.dart
+++ b/lib/src/file/download_file.dart
@@ -284,7 +284,7 @@ class DownloadFile {
     return access!;
   }
 
-  Future close() async {
+  Future<void> close() async {
     if (isClosed) return;
     _closed = true;
     try {
@@ -306,10 +306,9 @@ class DownloadFile {
       _streamController = null;
       _bytesRequestSubscription = null;
     }
-    return;
   }
 
-  Future flush() async {
+  Future<void> flush() async {
     try {
       await _writeAccess?.flush();
     } catch (e) {
@@ -317,15 +316,18 @@ class DownloadFile {
     }
   }
 
-  Future delete() async {
+  Future<FileSystemEntity?> delete() async {
     try {
       await close();
-    } finally {
       var temp = _file;
       _file = null;
+      // here we can get a FileSystemException
       var r = await temp?.delete();
       return r;
+    } catch (e) {
+      log('delete() error: ', error: e, name: runtimeType.toString());
     }
+    return null;
   }
 
   @override

--- a/lib/src/file/download_file.dart
+++ b/lib/src/file/download_file.dart
@@ -292,7 +292,9 @@ class DownloadFile {
       await _writeAccess?.flush();
       await _writeAccess?.close();
       await _readAccess?.close();
-      await hlsStreamController.close();
+      //  hlsStreamController can be closed by this moment via
+      //  _readAndPushBytes. So, the future never completes.
+      if (!hlsStreamController.isClosed) hlsStreamController.close();
     } catch (e) {
       log('Close file error:', error: e, name: runtimeType.toString());
     } finally {

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -127,6 +127,8 @@ class _TorrentTask
       _peerId; // This is the generated local peer ID, which is different from the ID used in the Peer class.
 
   ServerSocket? _serverSocket;
+
+  StreamSubscription<Socket>? _serverSocketListener;
   // ServerUTPSocket? _utpServer;
 
   final Set<InternetAddress> _comingIp = {};
@@ -303,7 +305,7 @@ class _TorrentTask
     // Incoming peer:
     _serverSocket ??= await ServerSocket.bind(InternetAddress.anyIPv4, 0);
     await _init(_metaInfo, _savePath);
-    _serverSocket?.listen(_hookInPeer);
+    _serverSocketListener = _serverSocket?.listen(_hookInPeer);
     // _utpServer ??= await ServerUTPSocket.bind(
     //     InternetAddress.anyIPv4, _serverSocket?.port ?? 0);
     // _utpServer?.listen(_hookUTP);
@@ -368,13 +370,14 @@ class _TorrentTask
     _tracker = null;
     await _peersManager?.dispose();
     _peersManager = null;
+    _serverSocketListener?.cancel();
+    _serverSocketListener = null;
     await _serverSocket?.close();
     _serverSocket = null;
     await _fileManager?.close();
     _fileManager = null;
     await _dht?.stop();
     _dht = null;
-
     _lsd?.close();
     _lsd = null;
     _peerIds.clear();

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -379,6 +379,7 @@ class _TorrentTask
     _lsd = null;
     _peerIds.clear();
     _comingIp.clear();
+    state = TaskState.stopped;
     return;
   }
 

--- a/test/torrent_client_test.dart
+++ b/test/torrent_client_test.dart
@@ -256,6 +256,15 @@ void main() {
       await stateFile.delete(); //Deleting twice.
       assert(!await t.exists());
     });
+
+    test('Stop task test', () async {
+      assert(torrent != null, 'No torrent provided');
+      final newTask = TorrentTask.newTask(torrent!, directory);
+      await newTask.start();
+      assert(newTask.state == TaskState.running);
+      await newTask.stop();
+      assert(newTask.state == TaskState.stopped);
+    });
   });
 
   group('Temp file access - ', () {


### PR DESCRIPTION
Issue Description
task.close() method never completes because of method close() called twice for _hlsStreamController.
This issue leads to the huge memory leaks.

What is the fix

- [x] Added conditional close in close() method for _hlsStreamController.

Additional info
- [x] Did little refractoring cleaning namespace and closed two more subscriptions.
- [x]  Added changing TorrentTask to TaskState.stopped after succesfull dispose.
- [x]  Added test.

Issue link(s)
https://github.com/moham96/dtorrent_task/issues/3