### PR TITLE
[FIX] Add incoming connection

### DIFF
--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -363,7 +363,7 @@ class _TorrentTask
       socket.close();
       return;
     }
-    if (_comingIp.length >= MAX_IN_PEERS || !_comingIp.add(socket.address)) {
+    if (_comingIp.length >= MAX_IN_PEERS || !_comingIp.add(socket.remoteAddress)) {
       socket.close();
       return;
     }
@@ -382,7 +382,7 @@ class _TorrentTask
       socket.close();
       return;
     }
-    if (_comingIp.length >= MAX_IN_PEERS || !_comingIp.add(socket.address)) {
+    if (_comingIp.length >= MAX_IN_PEERS || !_comingIp.add(socket.remoteAddress)) {
       socket.close();
       return;
     }


### PR DESCRIPTION
### Issue Description:
Before the fix, only one incoming peer could be added because we added the localhost address to the _incomingIp set instead of the remote peer address.

### What is the fix:
- [ ] Fixed adding new incoming peer address to _comingIp set.